### PR TITLE
Google tag の誤削除を戻す

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-E7WQKY0EJ2"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-E7WQKY0EJ2");
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>


### PR DESCRIPTION
## 実装内容

https://github.com/boxing708/deportaregym/commit/c60fab9438df21255db2acf4e85575330602c6fc で誤って削除されたタグを元に戻す